### PR TITLE
Allow php-fpm service to be reloaded

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -101,5 +101,6 @@ else
 end
 
 service php_fpm_service_name do
+  supports :status => true, :restart => true, :reload => true
   action [ :enable, :start ]
 end


### PR DESCRIPTION
Explicitly tell chef what actions the service supports, while restart works without this, reload does not and it's much nicer for live deploys.
