### PR TITLE
Change to install official PHP-fpm package in RHEL 6.4 / CentOS 6.4

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,16 +64,18 @@ when 'debian'
   end
 
 when 'amazon', 'fedora', 'centos', 'redhat'
-  yum_key 'RPM-GPG-KEY-remi' do
-    url 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
-  end
+  unless platform?('centos', 'redhat') && node['platform_version'].to_f >= 6.4
+    yum_key 'RPM-GPG-KEY-remi' do
+      url 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
+    end
 
-  yum_repository 'remi' do
-    description 'Remi'
-    url 'http://rpms.famillecollet.com/enterprise/$releasever/remi/$basearch/'
-    mirrorlist 'http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror'
-    key 'RPM-GPG-KEY-remi'
-    action :add
+    yum_repository 'remi' do
+      description 'Remi'
+      url 'http://rpms.famillecollet.com/enterprise/$releasever/remi/$basearch/'
+      mirrorlist 'http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror'
+      key 'RPM-GPG-KEY-remi'
+      action :add
+    end
   end
 end
 


### PR DESCRIPTION
RHEL 6.4 / CentOS 6.4 involve the official PHP-fpm package now. Although the Remi repository provides the PHP packages which is newer than official, I think installing the official package is a better way for consistency with the other official packages.
