### PR TITLE
Fix warning for deprecated comment method

### DIFF
--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -1,7 +1,7 @@
 ; Start a new pool named '<%= @pool_name %>'.
 [<%= @pool_name %>]
 
-# <%= [@params].flatten.join " " %>
+; <%= [@params].flatten.join " " %>
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:
 ;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific address on


### PR DESCRIPTION
PHP Deprecated:  Comments starting with '#' are deprecated
