### PR TITLE
fix issue #14

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -102,16 +102,18 @@ template node['php-fpm']['conf_file'] do
   mode 00644
   owner "root"
   group "root"
+  notifies, "service[php-fpm]", :delayed
 end
 
 node['php-fpm']['pools'].each do |pool|
   fpm_pool pool do
     php_fpm_service_name php_fpm_service_name
+    notifies, "service[php-fpm]", :delayed
   end
 end
 
 service "php-fpm" do
   service_name php_fpm_service_name
   supports :start => true, :stop => true, :restart => true, :reload => true
-  action [ :enable, :restart ]
+  action [ :enable, :start ]
 end


### PR DESCRIPTION
Fix Issue #14 via resource notifications:

 105     +  notifies, "service[php-fpm]", :delayed

 111  +    notifies, "service[php-fpm]", :delayed

send delayed notifications to service resource to make a reload action. Which will take place after the chef-run

On the first chef-client run only start the service
 116  -  action [ :enable, :restart ]
 118 +  action [ :enable, :start ]
