### PR TITLE
Added ability to set catch_workers_output setting in the pool config file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['php-fpm']['pool']['www']['start_servers'] = 5
 default['php-fpm']['pool']['www']['min_spare_servers'] = 5
 default['php-fpm']['pool']['www']['max_spare_servers'] = 35
 default['php-fpm']['pool']['www']['max_requests'] = 500
+default['php-fpm']['pool']['www']['catch_workers_output'] = "no"
 
 default['php-fpm']['pool']['testpool']['listen'] = "127.0.0.1:9001"
 default['php-fpm']['pool']['testpool']['allowed_clients'] = ["127.0.0.1"]
@@ -43,3 +44,4 @@ default['php-fpm']['pool']['testpool']['start_servers'] = 5
 default['php-fpm']['pool']['testpool']['min_spare_servers'] = 5
 default['php-fpm']['pool']['testpool']['max_spare_servers'] = 35
 default['php-fpm']['pool']['testpool']['max_requests'] = 500
+default['php-fpm']['pool']['testpool']['catch_workers_output'] = "no"

--- a/definitions/fpm_pool.rb
+++ b/definitions/fpm_pool.rb
@@ -46,6 +46,7 @@ define :fpm_pool, :template => "pool.conf.erb", :enable => true do
     :min_spare_servers => node['php-fpm']['pool'][pool_name]['min_spare_servers'],
     :max_spare_servers => node['php-fpm']['pool'][pool_name]['max_spare_servers'],
     :max_requests => node['php-fpm']['pool'][pool_name]['max_requests'],
+    :catch_workers_output => node['php-fpm']['pool'][pool_name]['catch_workers_output'],
     :params => params
     )
   end

--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -182,7 +182,7 @@ pm.max_requests = <%= @max_requests %>
 ; Redirect worker stdout and stderr into main error log. If not set, stdout and
 ; stderr will be redirected to /dev/null according to FastCGI specs.
 ; Default Value: no
-;catch_workers_output = yes
+catch_workers_output = <%= @catch_workers_output %>
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
This lets a user set the catch_workers_output setting. The default attributes for the www pool will set this option to off, which is the default for php-fpm.
