### PR TITLE
Set php_*values and php_*flags when provided

### DIFF
--- a/definitions/fpm_pool.rb
+++ b/definitions/fpm_pool.rb
@@ -47,6 +47,10 @@ define :fpm_pool, :template => "pool.conf.erb", :enable => true do
     :max_spare_servers => node['php-fpm']['pool'][pool_name]['max_spare_servers'],
     :max_requests => node['php-fpm']['pool'][pool_name]['max_requests'],
     :catch_workers_output => node['php-fpm']['pool'][pool_name]['catch_workers_output'],
+    :php_values => params[:php_values] || [],
+    :php_flags => params[:php_flags] || [],
+    :php_admin_values => params[:php_admin_values] || [],
+    :php_admin_flags => params[:php_admin_flags] || [],
     :params => params
     )
     notifies :restart, "service[php-fpm]"

--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -227,3 +227,18 @@ catch_workers_output = <%= @catch_workers_output %>
 ;php_value[session.save_handler] = files
 ;php_value[session.save_path] = /var/lib/php/session
 
+<% @php_values.each do |key, value| %>
+php_value[<%= key %>] = <%= value %>
+<% end %>
+
+<% @php_flags.each do |key, flag| %>
+php_flag[<%= key %>] = <%= flag %>
+<% end %>
+
+<% @php_admin_values.each do |key, value| %>
+php_admin_value[<%= key %>] = <%= value %>
+<% end %>
+
+<% @php_admin_flags.each do |key, flag| %>
+php_admin_flag[<%= key %>] = <%= flag %>
+<% end %>


### PR DESCRIPTION
When php__values or php__flags are set they will be added to the pool config.

```
    php_values(
      'session.save_path' => "/tmp/sessions",
      'upload_tmp_dir' => "/tmp/upload"
    )
    php_admin_flags(
      'log_errors' => 'on'
    )
```

results in

```
php_value[session.save_path] = /tmp/sessions
php_value[upload_tmp_dir] = /tmp/upload
php_admin_flag[log_errors] = on
```
