### PR TITLE
do not start php-fpm recipe. #26

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -115,5 +115,5 @@ service "php-fpm" do
   provider service_provider if service_provider
   service_name php_fpm_service_name
   supports :start => true, :stop => true, :restart => true, :reload => true
-  action [ :enable, :start ]
+  action [ :enable ]
 end


### PR DESCRIPTION
starting fpm from recipe makes initial installs to fail when config is
incomplete.

starting fpm service is handled from lrwp notification so starting from
recipe is not really neccessary.
