### PR TITLE
Support for overriding yum package and service names

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,3 +36,7 @@ default['php-fpm']['pools'] = [
     :name => "www"
   }
 ]
+default['php-fpm']['package_name'] = ""
+default['php-fpm']['service_name'] = ""
+default['php-fpm']['yum_url'] = "http://rpms.famillecollet.com/enterprise/$releasever/remi/$basearch/"
+default['php-fpm']['yum_mirrorlist'] = "http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,21 +85,25 @@ when 'amazon', 'fedora', 'centos', 'redhat'
 
     yum_repository 'remi' do
       description 'Remi'
-      url 'http://rpms.famillecollet.com/enterprise/$releasever/remi/$basearch/'
-      mirrorlist 'http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror'
+      url node['php-fpm']['yum_url']
+      mirrorlist node['php-fpm']['yum_mirrorlist']
       key 'RPM-GPG-KEY-remi'
       action :add
     end
   end
 end
 
-if platform_family?("rhel")
-  php_fpm_service_name = "php-fpm"
+if node['php-fpm']['package_name'].nil?
+	if platform_family?("rhel")
+	  php_fpm_package_name = "php-fpm"
+	else
+	  php_fpm_package_name = "php5-fpm"
+	end
 else
-  php_fpm_service_name = "php5-fpm"
+	php_fpm_package_name = node['php-fpm']['package_name']
 end
 
-package php_fpm_service_name do
+package php_fpm_package_name do
   action :upgrade
 end
 
@@ -109,6 +113,12 @@ template node['php-fpm']['conf_file'] do
   owner "root"
   group "root"
   notifies :restart, "service[php-fpm]"
+end
+
+if node['php-fpm']['service_name'].nil?
+	php_fpm_service_name = php_fpm_package_name
+else
+	php_fpm_service_name = node['php-fpm']['service_name']
 end
 
 service "php-fpm" do


### PR DESCRIPTION
Added support for changing php-fpm installation package, service name and yum repo URL, all to better facilitate use on modern Amazon Linux (2014.03).

At least in the most recent releases, this cookbook won't function with Amazon Linux for 3 reasons;
1. When opting to use more recent releases such as PHP 5.5, package names follow the moniker of php55-xxx, the existing php-fpm cookbook assumes it'll be one of two choices, restricting what packages can be installed.
2. The existing php-fpm cookbook assumes the init / service name is the same as the package name, however in at least the case of the "php5-fpm" package, the init script created differs (creating /etc/init.d/php-fpm-5.5) causing the php-fpm cookbook to fail restarting the service.
3. When using RHEL / yum for installation, the existing php-fpm cookbook attempts to use $releasever when installing a yum repo (Remi), Amazon Linux sets this to either "latest" or something along the lines of "2014.03" or "2013.09" which breaks compatibility with RHEL/CentOS based repos that expect a release number such as 6 or 7.

In all three cases, this pull request allows the user to override all the above whilst maintaining backwards-compatibility in case they choose not to. Enjoy :)
