### PR TITLE
Updating socket permissions

### DIFF
--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -43,7 +43,7 @@ listen = <%= @listen || "/var/run/php-fpm-#{@pool_name}.sock" %>
 ;                 mode is set to 0666
 ;listen.owner = nobody
 ;listen.group = nobody
-;listen.mode = 0666
+listen.mode = 0660
 
 ; List of ipv4 addresses of FastCGI clients which are allowed to connect.
 ; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original


### PR DESCRIPTION
Setting the default socket listening permissions to `0660` as a security precaution.  Leaving it set to `0666` can result in privilege escalation.

http://www.openwall.com/lists/oss-security/2014/04/29/5

> When using UNIX sockets, the socket's permissions default to 0666 if not
> overriden explicitly ("listen.mode"). This is true even if the owner of
> the socket is changed explicitly ("listen.user", "listen.group").
> 
> Depending on the concrete scenario, this may result in privilege escalation.
> Any local user with the ability to connect to UNIX sockets can run
> arbitrary (PHP) code with the target process pool's permissions [1].
