### PR TITLE
remove yum_key since it doesn’t exist in the yum cookbook 3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.6.9"
 
 depends "apt"
-depends "yum"
+depends "yum", ">= 3.0"
 
 %w{ debian ubuntu centos redhat fedora amazon }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,15 +79,11 @@ when 'debian'
 
 when 'amazon', 'fedora', 'centos', 'redhat'
   unless platform?('centos', 'redhat') && node['platform_version'].to_f >= 6.4
-    yum_key 'RPM-GPG-KEY-remi' do
-      url 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
-    end
-
     yum_repository 'remi' do
       description 'Remi'
       url node['php-fpm']['yum_url']
       mirrorlist node['php-fpm']['yum_mirrorlist']
-      key 'RPM-GPG-KEY-remi'
+      gpgkey 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
       action :add
     end
   end


### PR DESCRIPTION
Fixes #34
