### PR TITLE
Disable default www pool if not defined in pools attribute.

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -28,7 +28,7 @@ end
 
 php_fpm_pool 'www' do
   enable false
-end if node['php-fpm']['pools'].find { |v| v[:name] == 'www' }.nil?
+end
 
 if node['php-fpm']['pools']
   node['php-fpm']['pools'].each do |pool|


### PR DESCRIPTION
The package that's installed (at least on Ubuntu) will add `/etc/php5/fpm/pool.d/www.conf`. Thus, even if this pool is not in `node['php-fpm']['pools']`, it will still be enabled after the node converges.

This removes this stock pool unless it is detected in `node['php-fpm']['pools']`.
