### PR TITLE
Disabling security.limit_extensions with Ubuntu 10.04

### DIFF
--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -112,7 +112,7 @@ pm.max_children = <%= @max_children || 50 %>
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
 <% if @start_servers %>
- pm.start_servers = <%= @start_servers %>
+pm.start_servers = <%= @start_servers %>
 <% end %>
 
 ; The desired minimum number of idle server processes.
@@ -364,6 +364,7 @@ pm.max_requests = <%= @max_requests || 500 %>
 ; Default Value: no
 catch_workers_output = <%= @catch_workers_output || "no" %>
 
+<% if node['platform'] != 'ubuntu' && node['platform_version'] != '10.04' %>
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit
 ; FPM to .php extensions to prevent malicious users to use other extensions to
@@ -372,6 +373,7 @@ catch_workers_output = <%= @catch_workers_output || "no" %>
 ; Default Value: .php
 ;security.limit_extensions = .php .php3 .php4 .php5
 security.limit_extensions = <%=@security_limit_extensions || ".php" %>
+<% end %>
 
 ; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
 ; the current environment.


### PR DESCRIPTION
This is for adding support for Ubuntu 10.04.  The [security.limit_extensions](https://bugs.php.net/bug.php?id=60763) was added in with [PHP 5.3.9](https://bugs.php.net/bug.php?id=60763), Ubuntu 10.04 packaged [5.3.2](http://packages.ubuntu.com/lucid/php5).

PS - Ubuntu 10.04 will be EOL in April 2015.  Just trying to add up some backwards compatibility in another cookbook. The only other thing people will need to do is to ensure they set the [:process_manager](https://github.com/yevgenko/cookbook-php-fpm/blob/bd7ac6ca2d47bc8a086364e5cb4cbc24e1ae14d1/templates/default/pool.conf.erb#L97) to `static` or `dynamic`.  The `ondemand` option came in later.
