### PR TITLE
Don't always disable the default 'www' pool

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -26,7 +26,7 @@ template node['php-fpm']['conf_file'] do
   notifies :restart, "service[php-fpm]"
 end
 
-if !node['php-fpm']['pools'].key?('www')
+unless node['php-fpm']['pools'].key?('www')
   php_fpm_pool 'www' do
     enable false
   end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -26,8 +26,10 @@ template node['php-fpm']['conf_file'] do
   notifies :restart, "service[php-fpm]"
 end
 
-php_fpm_pool 'www' do
-  enable false
+if !node['php-fpm']['pools'].key?('www')
+  php_fpm_pool 'www' do
+    enable false
+  end
 end
 
 if node['php-fpm']['pools']


### PR DESCRIPTION
If using the default 'www' pool, this recipe always disables and re-enables it on every chef-client run. Don't run the `php_fpm_pool` disable statement if the pool explicitly exists in the `node['php-fpm']['pools']` attribute.