### PR TITLE
Don't use upgrade action, install is less bug prone

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,7 +32,7 @@ else
 end
 
 package php_fpm_package_name do
-  action :upgrade
+  action :install
 end
 
 if node['php-fpm']['service_name'].nil?


### PR DESCRIPTION
This upgrade action caused problem on servers where I used your cookbook.

After upgrade package installed conflicting config in /etc/php-fpm.d/ and php-fpm was unable to start becase proper configuration wasn't generated yet.

Upgrade of package should be aware action of admin so please accept this pull request and make this more admin friendly :)