### PR TITLE
Please use nil as default for default['php-fpm']['version']

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default['php-fpm']['pools'] = {
 
 default['php-fpm']['skip_repository_install'] = false
 default['php-fpm']['installation_action'] = :install
-default['php-fpm']['version'] = ''
+default['php-fpm']['version'] = nil
 
 default['php-fpm']['yum_url'] = "http://rpms.famillecollet.com/enterprise/$releasever/remi/$basearch/"
 default['php-fpm']['yum_mirrorlist'] = "http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,7 +32,7 @@ else
 end
 
 package php_fpm_package_name do
-  action :upgrade
+  action :install
 end
 
 if node['php-fpm']['service_name'].nil?


### PR DESCRIPTION
I suggest to use `nil` as default value for `default['php-fpm']['version']`. Empty string in Ruby is considered true, so this condition in version:

```
package php_fpm_package_name do
  action node['php-fpm']['installation_action']
  version node['php-fpm']['version'] if node['php-fpm']['version']
end
```

will always be true and because of that I have to explicitly enter there version or use `nil`. In my opinion `nil` is just better value there (to get current version of package) :)