### PR TITLE
Split debian 7 & 8 support

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -38,10 +38,18 @@ when 'debian'
   # Configure Dotdeb repos
   # TODO: move this to it's own 'dotdeb' cookbook?
   # http://www.dotdeb.org/instructions/
-  if node.platform_version.to_f >= 7.0
+  if node.platform_version.to_f >= 8.0
     apt_repository "dotdeb" do
       uri node['php-fpm']['dotdeb_repository']['uri']
-      distribution "stable"
+      distribution "jessie"
+      components ['all']
+      key node['php-fpm']['dotdeb_repository']['key']
+      action :add
+    end
+  elsif node.platform_version.to_f >= 7.0
+    apt_repository "dotdeb" do
+      uri node['php-fpm']['dotdeb_repository']['uri']
+      distribution "wheezy"
       components ['all']
       key node['php-fpm']['dotdeb_repository']['key']
       action :add


### PR DESCRIPTION
In current version if you are using Debian 7, aptitude will try to install Debian 8 packages (as they are marked as stable) and will fail. I split them up so everyone will use only their own packages.