### PR TITLE
Added definitions for slowlog

### DIFF
--- a/definitions/php_fpm_pool.rb
+++ b/definitions/php_fpm_pool.rb
@@ -49,8 +49,8 @@ define :php_fpm_pool, :template => "pool.conf.erb", :enable => true do
         :catch_workers_output => params[:catch_workers_output],
         :security_limit_extensions => params[:security_limit_extensions] || node['php-fpm']['security_limit_extensions'],
         :access_log => params[:access_log] || false,
-        :slowlog => params[:slowlog],
-        :request_slowlog_timeout => params[:request_slowlog_timeout],
+        :slowlog => params[:slowlog] || false,
+        :request_slowlog_timeout => params[:request_slowlog_timeout] || false,
         :php_options => params[:php_options] || {},
         :request_terminate_timeout => params[:request_terminate_timeout],
         :params => params

--- a/definitions/php_fpm_pool.rb
+++ b/definitions/php_fpm_pool.rb
@@ -49,6 +49,8 @@ define :php_fpm_pool, :template => "pool.conf.erb", :enable => true do
         :catch_workers_output => params[:catch_workers_output],
         :security_limit_extensions => params[:security_limit_extensions] || node['php-fpm']['security_limit_extensions'],
         :access_log => params[:access_log] || false,
+        :slowlog => params[:slowlog],
+        :request_slowlog_timeout => params[:request_slowlog_timeout],
         :php_options => params[:php_options] || {},
         :request_terminate_timeout => params[:request_terminate_timeout],
         :params => params

--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -319,13 +319,13 @@ access.log = <%= node['php-fpm']['log_dir'] %>/$pool.access.log
 ; The log file for slow requests
 ; Default Value: not set
 ; Note: slowlog is mandatory if request_slowlog_timeout is set
-;slowlog = log/$pool.log.slow
+slowlog = <%=@slowlog || 'log/$pool.log.slow' %>
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-;request_slowlog_timeout = 0
+request_slowlog_timeout = <%=@request_slowlog_timeout || 0 %>
 
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option

--- a/templates/default/pool.conf.erb
+++ b/templates/default/pool.conf.erb
@@ -319,13 +319,21 @@ access.log = <%= node['php-fpm']['log_dir'] %>/$pool.access.log
 ; The log file for slow requests
 ; Default Value: not set
 ; Note: slowlog is mandatory if request_slowlog_timeout is set
+<% if @slowlog %>
 slowlog = <%=@slowlog || 'log/$pool.log.slow' %>
+<% else %>
+;slowlog = log/$pool.log.slow
+<% end %>
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
+<% if @request_slowlog_timeout %>
 request_slowlog_timeout = <%=@request_slowlog_timeout || 0 %>
+<% else %>
+;request_slowlog_timeout = 0
+<% end %>
 
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option


### PR DESCRIPTION
I needed to enable the slowlog so I patched this cookbook to support the slowlog and request_slowlog_timeout directives for the pool template.

Hope it helps