### PR TITLE
Add support for Ubuntu 16.04's php 7.0 packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,8 +7,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.4
-  - name: fedora-21
+  - name: ubuntu-16.04
+  - name: centos-6.7
+  - name: fedora-23
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,15 +10,22 @@ when "rhel", "fedora"
 else
   user = "www-data"
   group = "www-data"
-  conf_dir = "/etc/php5/fpm/conf.d"
-  pool_conf_dir = "/etc/php5/fpm/pool.d"
-  if node.platform == "ubuntu" and node.platform_version.to_f <= 10.04
-    conf_file = "/etc/php5/fpm/php5-fpm.conf"
+  if platform?('ubuntu') and node.platform_version.to_f >= 16.04
+    php_conf_dir = "/etc/php/7.0"
+    php_fpm_name = "php7.0-fpm"
   else
-    conf_file = "/etc/php5/fpm/php-fpm.conf"
+    php_conf_dir = "/etc/php5"
+    php_fpm_name = "php5-fpm"
   end
-  error_log = "/var/log/php5-fpm.log"
-  pid ="/var/run/php5-fpm.pid"
+  conf_dir = "#{php_conf_dir}/fpm/conf.d"
+  pool_conf_dir = "#{php_conf_dir}/fpm/pool.d"
+  if node.platform == "ubuntu" and node.platform_version.to_f <= 10.04
+    conf_file = "#{php_conf_dir}/fpm/php5-fpm.conf"
+  else
+    conf_file = "#{php_conf_dir}/fpm/php-fpm.conf"
+  end
+  error_log = "/var/log/#{php_fpm_name}.log"
+  pid = "/var/run/#{php_fpm_name}.pid"
 end
 
 default['php-fpm']['user'] = user

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,6 +24,8 @@ include_recipe 'apt::default' if node['platform_family'] == 'debian'
 if node['php-fpm']['package_name'].nil?
   if platform_family?("rhel", "fedora")
     php_fpm_package_name = "php-fpm"
+  elsif platform?('ubuntu') and node['platform_version'].to_f >= 16.04
+    php_fpm_package_name = "php7.0-fpm"
   else
     php_fpm_package_name = "php5-fpm"
   end
@@ -43,7 +45,8 @@ else
 end
 
 service_provider = nil
-if node['platform'] == 'ubuntu' and node['platform_version'].to_f >= 13.10
+# this is actually already done in chef, but is kept here for older chef releases
+if platform?('ubuntu') and node['platform_version'].to_f.between?(13.10, 14.10)
   service_provider = ::Chef::Provider::Service::Upstart
 end
 


### PR DESCRIPTION
Note, the service provider changed to systemd in 15.04, and the latest version of chef knows 13.10 uses upstart, however I'm keeping the original code for the service provider in, so this can be part of a BC release.
