### PR TITLE
Removed RH/CentOS hard version dependency

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -72,13 +72,11 @@ when 'debian'
   end
 
 when 'amazon', 'fedora', 'centos', 'redhat'
-  unless platform?('centos', 'redhat') && node['platform_version'].to_f >= 6.4
-    yum_repository 'remi' do
-      description 'Remi'
-      url node['php-fpm']['yum_url']
-      mirrorlist node['php-fpm']['yum_mirrorlist']
-      gpgkey 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
-      action :add
-    end
+  yum_repository 'remi' do
+    description 'Remi'
+    url node['php-fpm']['yum_url']
+    mirrorlist node['php-fpm']['yum_mirrorlist']
+    gpgkey 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi'
+    action :add
   end
 end


### PR DESCRIPTION
We shouldn't limit the user on adding the remi repo based on RH version. With this configuration there's literally no way of installing PHP 5.6 on CentOS 6.7 using this cookbook.
The user can still skip installing additional repo providing `node['php-fpm']['skip_repository_install']`