### PR TITLE
Update method access for node attributes for chef 13

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ when "rhel", "fedora"
 else
   user = "www-data"
   group = "www-data"
-  if platform?('ubuntu') and node.platform_version.to_f >= 16.04
+  if platform?('ubuntu') and node['platform_version'].to_f >= 16.04
     php_conf_dir = "/etc/php/7.0"
     php_fpm_name = "php7.0-fpm"
   else
@@ -19,7 +19,7 @@ else
   end
   conf_dir = "#{php_conf_dir}/fpm/conf.d"
   pool_conf_dir = "#{php_conf_dir}/fpm/pool.d"
-  if node.platform == "ubuntu" and node.platform_version.to_f <= 10.04
+  if node['platform'] == "ubuntu" and node['platform_version'].to_f <= 10.04
     conf_file = "#{php_conf_dir}/fpm/php5-fpm.conf"
   else
     conf_file = "#{php_conf_dir}/fpm/php-fpm.conf"

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -38,7 +38,7 @@ when 'debian'
   # Configure Dotdeb repos
   # TODO: move this to it's own 'dotdeb' cookbook?
   # http://www.dotdeb.org/instructions/
-  if node.platform_version.to_f >= 8.0
+  if node['platform_version'].to_f >= 8.0
     apt_repository "dotdeb" do
       uri node['php-fpm']['dotdeb_repository']['uri']
       distribution "jessie"
@@ -46,7 +46,7 @@ when 'debian'
       key node['php-fpm']['dotdeb_repository']['key']
       action :add
     end
-  elsif node.platform_version.to_f >= 7.0
+  elsif node['platform_version'].to_f >= 7.0
     apt_repository "dotdeb" do
       uri node['php-fpm']['dotdeb_repository']['uri']
       distribution "wheezy"
@@ -54,7 +54,7 @@ when 'debian'
       key node['php-fpm']['dotdeb_repository']['key']
       action :add
     end
-  elsif node.platform_version.to_f >= 6.0
+  elsif node['platform_version'].to_f >= 6.0
     apt_repository "dotdeb" do
       uri node['php-fpm']['dotdeb_repository']['uri']
       distribution "squeeze"


### PR DESCRIPTION
node.foo.bar is deprecated and will be removed  in chef 13

Signed-off-by: Topher Cullen <topher.cullen@jamberry.com>