### PR TITLE
Support for 'amazon' as platform family.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   user = 'apache'
   group = 'apache'
   conf_dir = '/etc/php.d'


### PR DESCRIPTION
Added amazon as alternative to rhel and fedora for platform family evaluation. Check ohai output when running Amazon linux.
Fixes #106 